### PR TITLE
https all the links, plus updates

### DIFF
--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -11,7 +11,7 @@ The Shapely User Manual
   This work is licensed under a `Creative Commons Attribution 3.0
   United States License`__.
 
-.. __: http://creativecommons.org/licenses/by/3.0/us/
+.. __: https://creativecommons.org/licenses/by/3.0/us/
 
 :Abstract:
   This document explains how to use the Shapely Python package for
@@ -107,7 +107,7 @@ The standard data model has additional constraints specific to certain types
 of geometric objects that will be discussed in following sections of this
 manual.
 
-See also http://www.vividsolutions.com/jts/discussion.htm#spatialDataModel
+See also https://web.archive.org/web/20160719195511/http://www.vividsolutions.com/jts/discussion.htm
 for more illustrations of this data model.
 
 .. _intro-relationships:
@@ -1348,7 +1348,7 @@ the square.
   '0F2FF1FF2'
 
 Further discussion of the DE-9IM matrix is beyond the scope of this manual. See
-[4]_ and http://pypi.python.org/pypi/de9im.
+[4]_ and https://pypi.org/project/de9im/.
 
 .. _analysis-methods:
 
@@ -2649,18 +2649,18 @@ References
    1973, pp. 112-122.
 
 
-.. _GEOS: http://trac.osgeo.org/geos/
-.. _Java Topology Suite: https://www.locationtech.org/projects/technology.jts
-.. _JTS: https://www.locationtech.org/projects/technology.jts
+.. _GEOS: https://trac.osgeo.org/geos/
+.. _Java Topology Suite: https://projects.eclipse.org/projects/locationtech.jts
+.. _JTS: https://projects.eclipse.org/projects/locationtech.jts
 .. _PostGIS: http://postgis.refractions.net
-.. _record: http://pypi.python.org/pypi/Shapely
+.. _record: https://pypi.org/project/Shapely/
 .. _Open Geospatial Consortium: http://www.opengeospatial.org/
-.. _Davis: http://lin-ear-th-inking.blogspot.com/2007/06/subtleties-of-ogc-covers-spatial.html
+.. _Davis: https://lin-ear-th-inking.blogspot.com/2007/06/subtleties-of-ogc-covers-spatial.html
 .. _Understanding spatial relations: http://edndoc.esri.com/arcsde/9.1/general_topics/understand_spatial_relations.htm
-.. _Strobl-PDF: http://giswiki.hsr.ch/images/3/3d/9dem_springer.pdf
+.. _Strobl-PDF: https://giswiki.hsr.ch/images/3/3d/9dem_springer.pdf
 .. |Strobl-PDF| replace:: PDF
-.. _JTS-PDF: http://www.vividsolutions.com/jts/bin/JTS%20Technical%20Specs.pdf
+.. _JTS-PDF: https://github.com/locationtech/jts/raw/master/doc/JTS%20Technical%20Specs.pdf
 .. |JTS-PDF| replace:: PDF
-.. _frozenset: http://docs.python.org/library/stdtypes.html#frozenset
-.. _Sorting HowTo: http://wiki.python.org/moin/HowTo/Sorting/
-.. _Python geo interface: http://gist.github.com/2217756
+.. _frozenset: https://docs.python.org/library/stdtypes.html#frozenset
+.. _Sorting HowTo: https://wiki.python.org/moin/HowTo/Sorting/
+.. _Python geo interface: https://gist.github.com/2217756


### PR DESCRIPTION
* https where available (tested!).
* also updated JTS URLs to where they go redirected/migrated to.
* could not find a recent URL for http://www.vividsolutions.com/jts/discussion.htm#spatialDataModel (not in https://github.com/locationtech/jts/tree/gh-pages/), so I pointed it to IA's latest: https://web.archive.org/web/20160719195511/http://www.vividsolutions.com/jts/discussion.htm.